### PR TITLE
Issue #11 compose text inner padding 불일치

### DIFF
--- a/app/src/main/java/com/uzun/pseudosendy/MainActivity.kt
+++ b/app/src/main/java/com/uzun/pseudosendy/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.uzun.pseudosendy.presentation.ui.orderform.OrderFormScreen
-import com.uzun.pseudosendy.presentation.ui.orderform.main.PreviewOrderTypeCards
 import com.uzun.pseudosendy.ui.theme.PseudoSendyTheme
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/uzun/pseudosendy/presentation/ui/common/StyleButtons.kt
+++ b/app/src/main/java/com/uzun/pseudosendy/presentation/ui/common/StyleButtons.kt
@@ -42,8 +42,9 @@ fun BaseRoundedButton(
         shape = RoundedCornerShape(type.radius),
         colors = colors,
         modifier = modifier
-            .padding(vertical = type.padding)
-            .width(type.width),
+            .fillMaxWidth(),
+//            .width(type.width),
+        contentPadding = PaddingValues(type.padding),
         content = content
     )
 }
@@ -60,9 +61,9 @@ fun BaseSquareButton(
         onClick = onClick,
         shape = RoundedCornerShape(0.dp),
         colors = colors,
-        modifier = modifier
-            .padding(vertical = type.padding)
-            .width(type.width),
+        modifier = modifier.fillMaxWidth(),
+//            .width(type.width)
+        contentPadding = PaddingValues(type.padding),
         content = content
     )
 }

--- a/app/src/main/java/com/uzun/pseudosendy/presentation/ui/orderform/main/OrderFormMainScreen.kt
+++ b/app/src/main/java/com/uzun/pseudosendy/presentation/ui/orderform/main/OrderFormMainScreen.kt
@@ -1,22 +1,19 @@
 package com.uzun.pseudosendy.presentation.ui.orderform.main
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.PlatformTextStyle
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.sp
 import com.uzun.pseudosendy.presentation._const.UIConst.SPACE_XL
 import com.uzun.pseudosendy.presentation._const.UIConst.SPACE_XS
-import com.uzun.pseudosendy.presentation.ui.common.ButtonSize
 import com.uzun.pseudosendy.presentation.ui.common.RoundedPrimaryButton
-import com.uzun.pseudosendy.ui.theme.NotoSansKR
 import com.uzun.pseudosendy.ui.theme.PseudoSendyTheme
-
 
 @Composable
 fun OrderFormMainScreen() {
@@ -32,49 +29,24 @@ fun OrderFormMainScreen() {
 
 @Composable
 fun BoxScope.OrderFormContent() =
-    Column(modifier = Modifier.fillMaxSize()) {
-        OrderFormMainHeadTextArea()
-        Spacer(Modifier.size(SPACE_XL))
-        OrderTypeCards()
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        orderFormMainHeadTextArea()
+        item { Spacer(Modifier.size(SPACE_XL)) }
+        orderTypeCards()
     }
 
-@Composable
-fun ColumnScope.OrderFormMainHeadTextArea() {
+fun LazyListScope.orderFormMainHeadTextArea() = item {
     Text(text = "센디 용달 예약하기", style = PseudoSendyTheme.typography.XLBold)
     Spacer(Modifier.size(SPACE_XS))
     Text(text = "원하시는 항목부터 입력해주세요", style = PseudoSendyTheme.typography.Normal)
 }
 
-
-@Composable
-fun OrderTypeCards() {
-    Column(verticalArrangement = Arrangement.spacedBy(SPACE_XS)) {
-        OrderTypeCard(
-            type = CardType.DATETIME,
-            onClick = {},
-        ) {
-
+fun LazyListScope.orderTypeCards() {
+    CardType.values().forEach { cardType ->
+        item{
+            OrderTypeCard(type = cardType) {}
+            Spacer(Modifier.size(SPACE_XS))
         }
-
-        OrderTypeCard(
-            type = CardType.LOCATION,
-            onClick = {},
-        ) { }
-
-        OrderTypeCard(
-            type = CardType.VEHICLE,
-            onClick = {},
-        ) { }
-
-        OrderTypeCard(
-            type = CardType.LOAD_DETAIL,
-            onClick = {},
-        ) { }
-
-        OrderTypeCard(
-            type = CardType.SERVICE_OPTION,
-            onClick = {},
-        ) { }
     }
 }
 
@@ -84,7 +56,9 @@ fun BoxScope.CheckTransportationFeeButton(
 ) {
     RoundedPrimaryButton(
         onClick = onClick,
-        modifier = Modifier.align(Alignment.BottomCenter),
+        modifier = Modifier
+            .align(Alignment.BottomCenter)
+            .padding(bottom = SPACE_XL),
     ) {
         Text(
             text = "운송비용 확인하기",
@@ -97,6 +71,8 @@ fun BoxScope.CheckTransportationFeeButton(
 @Composable
 fun PreviewOrderFormMainScreen() {
     PseudoSendyTheme {
-        OrderFormMainScreen()
+        Column(Modifier.background(Color.White).fillMaxSize()) {
+            OrderFormMainScreen()
+        }
     }
 }

--- a/app/src/main/java/com/uzun/pseudosendy/presentation/ui/orderform/main/OrderFormMainScreen.kt
+++ b/app/src/main/java/com/uzun/pseudosendy/presentation/ui/orderform/main/OrderFormMainScreen.kt
@@ -5,14 +5,19 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
 import com.uzun.pseudosendy.presentation._const.UIConst.SPACE_XL
 import com.uzun.pseudosendy.presentation._const.UIConst.SPACE_XS
 import com.uzun.pseudosendy.presentation.ui.common.ButtonSize
 import com.uzun.pseudosendy.presentation.ui.common.RoundedPrimaryButton
+import com.uzun.pseudosendy.ui.theme.NotoSansKR
 import com.uzun.pseudosendy.ui.theme.PseudoSendyTheme
 
-@Preview
+
 @Composable
 fun OrderFormMainScreen() {
     Box(
@@ -26,15 +31,12 @@ fun OrderFormMainScreen() {
 }
 
 @Composable
-fun BoxScope.OrderFormContent(
-    modifier: Modifier = Modifier.fillMaxSize(),
-) {
-    Column(modifier) {
+fun BoxScope.OrderFormContent() =
+    Column(modifier = Modifier.fillMaxSize()) {
         OrderFormMainHeadTextArea()
         Spacer(Modifier.size(SPACE_XL))
         OrderTypeCards()
     }
-}
 
 @Composable
 fun ColumnScope.OrderFormMainHeadTextArea() {
@@ -83,11 +85,18 @@ fun BoxScope.CheckTransportationFeeButton(
     RoundedPrimaryButton(
         onClick = onClick,
         modifier = Modifier.align(Alignment.BottomCenter),
-        type = ButtonSize.LARGE
     ) {
         Text(
             text = "운송비용 확인하기",
             style = PseudoSendyTheme.typography.Normal
         )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewOrderFormMainScreen() {
+    PseudoSendyTheme {
+        OrderFormMainScreen()
     }
 }

--- a/app/src/main/java/com/uzun/pseudosendy/presentation/ui/orderform/main/OrderTypeCard.kt
+++ b/app/src/main/java/com/uzun/pseudosendy/presentation/ui/orderform/main/OrderTypeCard.kt
@@ -1,6 +1,5 @@
 package com.uzun.pseudosendy.presentation.ui.orderform.main
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border

--- a/app/src/main/java/com/uzun/pseudosendy/ui/theme/Type.kt
+++ b/app/src/main/java/com/uzun/pseudosendy/ui/theme/Type.kt
@@ -1,10 +1,12 @@
 package com.uzun.pseudosendy.ui.theme
 
+import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.uzun.pseudosendy.R
 import javax.annotation.concurrent.Immutable
@@ -19,98 +21,33 @@ val NotoSansKR = FontFamily(
     Font(R.font.notosanskr_thin, FontWeight.Thin, FontStyle.Normal),
 )
 
+fun getNotoSansTextStyle(fontSize : TextUnit, weight: FontWeight = FontWeight.Normal) = TextStyle(
+    fontFamily = NotoSansKR,
+    fontWeight = weight,
+    fontSize = fontSize,
+    platformStyle = PlatformTextStyle(includeFontPadding = false),
+)
+
 @Immutable
 data class SendyTypography(
-    val XXXLBold : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Bold,
-        fontSize = 32.sp
-    ),
-    val XXXL : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
-        fontSize = 32.sp
-    ),
-    val XXLBold : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Bold,
-        fontSize = 28.sp
-    ),
-    val XXL : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
-        fontSize = 28.sp
-    ),
-    val XLBold : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Bold,
-        fontSize = 24.sp
-    ),
-    val XL : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
-        fontSize = 24.sp
-    ),
-    val LargeBold : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Bold,
-        fontSize = 20.sp
-    ),
-    val Large : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
-        fontSize = 20.sp
-    ),
-    val MediumBold : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Bold,
-        fontSize = 18.sp
-    ),
-    val Medium : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
-        fontSize = 18.sp
-    ),
-    val NormalBold : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Bold,
-        fontSize = 16.sp
-    ),
-    val Normal : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp
-    ),
-    val SmallBold : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Bold,
-        fontSize = 14.sp
-    ),
-    val Small : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
-        fontSize = 14.sp
-    ),
-    val XSBold : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Bold,
-        fontSize = 13.sp
-    ),
-    val XS : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
-        fontSize = 13.sp
-    ),
-    val XXSBold : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Bold,
-        fontSize = 12.sp
-    ),
-    val XXS : TextStyle = TextStyle(
-        fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.sp
-    ),
+    val XXXLBold : TextStyle = getNotoSansTextStyle(32.sp, FontWeight.Bold),
+    val XXXL : TextStyle = getNotoSansTextStyle(32.sp),
+    val XXLBold : TextStyle = getNotoSansTextStyle(28.sp, FontWeight.Bold),
+    val XXL : TextStyle = getNotoSansTextStyle(28.sp),
+    val XLBold : TextStyle = getNotoSansTextStyle(24.sp, FontWeight.Bold),
+    val XL : TextStyle = getNotoSansTextStyle(24.sp),
+    val LargeBold : TextStyle = getNotoSansTextStyle(20.sp, FontWeight.Bold),
+    val Large : TextStyle = getNotoSansTextStyle(20.sp),
+    val MediumBold : TextStyle = getNotoSansTextStyle(18.sp, FontWeight.Bold),
+    val Medium : TextStyle = getNotoSansTextStyle(18.sp),
+    val NormalBold : TextStyle = getNotoSansTextStyle(16.sp, FontWeight.Bold),
+    val Normal : TextStyle = getNotoSansTextStyle(16.sp),
+    val SmallBold : TextStyle = getNotoSansTextStyle(14.sp, FontWeight.Bold),
+    val Small : TextStyle = getNotoSansTextStyle(14.sp),
+    val XSBold : TextStyle = getNotoSansTextStyle(13.sp, FontWeight.Bold),
+    val XS : TextStyle = getNotoSansTextStyle(13.sp),
+    val XXSBold : TextStyle = getNotoSansTextStyle(12.sp, FontWeight.Bold),
+    val XXS : TextStyle = getNotoSansTextStyle(12.sp),
 )
 
 val sendyTypography = SendyTypography()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46425142/223284337-dae2dd4a-4630-422f-bfd1-bec699de8423.png)

### 1 . 여백 생성 이슈

<img width="928" alt="image" src="https://user-images.githubusercontent.com/46425142/223284687-6b852140-a923-495f-89da-a0a42c31f62e.png">

- TextStyle에서 `platformStyle(innerFontPadding = false)` 적용
- 기존의 중복 코드에서 공통 확장 함수를 만들어 리팩토링

### 2. 버튼 패딩 수치 조정
![image](https://user-images.githubusercontent.com/46425142/223285134-dd0dddb5-d7e5-41a8-a4ae-0a473eae3931.png)

버튼이 적당해짐

### 3. OrderFormTypeCard 반복문으로 구현
<img width="623" alt="image" src="https://user-images.githubusercontent.com/46425142/223285171-f7942c59-7563-484a-b797-89ff0e01e379.png">

issue
- 어떻게 각각 다른 content 들을 구현할 것인가?
- 어떻게 각각 다른 navigate 들을 넣어줄것인가?


close #11 
